### PR TITLE
JS loading issues with jquery.gritter.min.js

### DIFF
--- a/lib/gritter/assets/javascripts/jquery.gritter.min.js
+++ b/lib/gritter/assets/javascripts/jquery.gritter.min.js
@@ -1,4 +1,4 @@
-(function($){$.gritter={};$.gritter.options={fade_in_speed:'medium',fade_out_speed:1000,time:6000}
+$(document).ready(function() {$.gritter={};$.gritter.options={fade_in_speed:'medium',fade_out_speed:1000,time:6000}
 $.gritter.add=function(params){try{return Gritter.add(params||{});}catch(e){var err='Gritter Error: '+e;(typeof(console)!='undefined'&&console.error)?console.error(err,params):alert(err);}}
 $.gritter.remove=function(id,params){Gritter.removeSpecific(id,params||{});}
 $.gritter.removeAll=function(params){Gritter.stop(params||{});}
@@ -16,4 +16,4 @@ this._fade(e,unique_id,params||{},unbind_events);},_restoreItemIfFading:function
 this._is_setup=1;},_setFadeTimer:function(e,unique_id){var timer_str=(this._custom_timer)?this._custom_timer:this.time;this['_int_id_'+unique_id]=setTimeout(function(){Gritter._fade(e,unique_id);},timer_str);},stop:function(params){var before_close=($.isFunction(params.before_close))?params.before_close:function(){};var after_close=($.isFunction(params.after_close))?params.after_close:function(){};var wrap=$('#gritter-notice-wrapper');before_close(wrap);wrap.fadeOut(function(){$(this).remove();after_close();});},_str_replace:function(search,replace,subject,count){var i=0,j=0,temp='',repl='',sl=0,fl=0,f=[].concat(search),r=[].concat(replace),s=subject,ra=r instanceof Array,sa=s instanceof Array;s=[].concat(s);if(count){this.window[count]=0;}
 for(i=0,sl=s.length;i<sl;i++){if(s[i]===''){continue;}
 for(j=0,fl=f.length;j<fl;j++){temp=s[i]+'';repl=ra?(r[j]!==undefined?r[j]:''):r[0];s[i]=(temp).split(f[j]).join(repl);if(count&&s[i]!==temp){this.window[count]+=(temp.length-s[i].length)/f[j].length;}}}
-return sa?s:s[0];},_verifyWrapper:function(){if($('#gritter-notice-wrapper').length==0){$('body').append(this._tpl_wrap);}}}})(jQuery);
+return sa?s:s[0];},_verifyWrapper:function(){if($('#gritter-notice-wrapper').length==0){$('body').append(this._tpl_wrap);}}}})


### PR DESCRIPTION
I experienced a loading issue for jquery.gritter.min.js - the code worked only when executed in the JS console, and else it was not loaded at all (Chrome 9, FF 4). I have changed the code to "$(document).ready(function()..." so it loads fine - if you like it, please pull it :) I'm no JS pro though, perhaps there are reason not to do it..
It's a neat gem, thx for everything!
