### PR TITLE
Don't show popup until page loaded

### DIFF
--- a/lib/gritter/helpers.rb
+++ b/lib/gritter/helpers.rb
@@ -16,7 +16,8 @@ module Gritter
       options = args.extract_options!
       options[:title] = "Notification" if options[:title].blank?
       options[:image] = ::Rails.version < "3.1" ? "/images/gritter/#{options[:image]}.png" : asset_path("#{options[:image]}.png") if %w(success warning error notice progress).include?(options[:image].to_s)
-      notification = ["jQuery.gritter.add({"]
+      notification = ["jQuery(function(){"]
+      notification.push("jQuery.gritter.add({")
       notification.push("image:'#{options[:image]}',") if options[:image].present?
       notification.push("sticky:#{options[:sticky]},") if options[:sticky].present?
       notification.push("time:#{options[:time]},") if options[:time].present?
@@ -27,6 +28,7 @@ module Gritter
       notification.push("after_close:function(e){#{options[:after_close]}},") if options[:after_close].present?
       notification.push("title:'#{escape_javascript(options[:title])}',")
       notification.push("text:'#{escape_javascript(text)}'")
+      notification.push("});")
       notification.push("});")
       text.present? ? notification.join.html_safe : nil
     end


### PR DESCRIPTION
I've got this error in IE8:

```
Here's the error:

Webpage error details

User Agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; InfoPath.2; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)
Timestamp: Fri, 16 Sep 2011 20:46:31 UTC

Message: HTML Parsing Error: Unable to modify the parent container element before the child element is closed (KB927917)
Line: 0
Char: 0
Code: 0
```

The solution is to wrap grittier call into `$(function(){...})`
