### PR TITLE
let namespaced controller to have own key chain

### DIFF
--- a/lib/gritter/gflash.rb
+++ b/lib/gritter/gflash.rb
@@ -45,7 +45,7 @@ module Gritter
     
     def gflash_translation(key)
       i18n_key = "gflash.#{params[:controller]}.#{params[:action]}.#{key}"
-      I18n.t(i18n_key.gsub(/\//, "."), :default => i18n_key)
+      I18n.t(i18n_key.gsub(/\//, "."), :default => i18n_key.to_sym)
     end
   end
 end


### PR DESCRIPTION
I noticed that flashes in namespaced controllers have 'bad' i18n keys like `gflash.admin/tags.create.notice`, so I hope my patch do it better, like `gflash.admin.tags.create.notice`, and all controllers under Admin namespace will be in own `.admin` key space in locale file.

Also, I leave old behavior for back compability.
