### PR TITLE
update helpers.rb

### DIFF
--- a/lib/gritter/helpers.rb
+++ b/lib/gritter/helpers.rb
@@ -55,7 +55,7 @@ module Gritter
         flashes = []
         session[:gflash].each do |key, value|
           value.each do |gflash_value|
-            gritter_options = { :image => key, :title => titles[key], :nodom_wrap => nodom_wrap }
+            gritter_options = { :image => key, :title => titles[key.to_sym], :nodom_wrap => nodom_wrap }
             if gflash_value.is_a?(Hash)
               text = gflash_value.has_key?(:value) ? (gflash_value[:value] and gflash_value.delete(:value)) : nil
               gritter_options.merge!(gflash_value)


### PR DESCRIPTION
If you use translations and titles definition in your locale.yml, they are totally ignored because `key` is always used as symbol in gflash_titles method but not in gflash method at row 58.
