### PR TITLE
Explicitly use image_path instead of asset_path

### DIFF
--- a/lib/gritter/helpers.rb
+++ b/lib/gritter/helpers.rb
@@ -3,7 +3,7 @@ module Gritter
     def add_gritter text, *args
       options = args.extract_options!
       options[:title] = "Notification" if options[:title].blank?
-      options[:image] = asset_path("#{options[:image]}#{options[:image].to_s == 'progress' ? '.gif' : '.png'}") if %w(success warning error notice progress).include?(options[:image].to_s)
+      options[:image] = image_path("#{options[:image]}#{options[:image].to_s == 'progress' ? '.gif' : '.png'}") if %w(success warning error notice progress).include?(options[:image].to_s)
       notification = Array.new
       notification.push("jQuery(function(){") if options[:nodom_wrap].blank?
       notification.push("jQuery.gritter.add({")


### PR DESCRIPTION
This update is somewhat self serving, as an app I am using gritter in has resources named `:asset`, so the `asset_path` helper does not work properly.  I think `image_path` should work here just as well, and is a bit more explicit about the kind of path you're trying to build.
